### PR TITLE
Update bug.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,7 +1,7 @@
 name: 🐞 Bug
 description: File a bug/issue
 title: "[BUG] <title>"
-labels: [bug,needs-triage]
+labels: [bug]
 body:
 - type: textarea
   attributes:


### PR DESCRIPTION
Update the bug.yml template to remove the "needs-triage" label. Instead, the lack of a triage label will indicate that an issue still needs to be triaged. Once an issue has been triaged, the "triaged" label should be added by the responsible team.