### PR TITLE
Update SUPPORT.md with note that MAUI DevKit isn't yet supported by CSS

### DIFF
--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -9,4 +9,4 @@ issues](https://github.com/microsoft/vscode-dotnettools/issues) before filing ne
 
 Support for this extension is primarily made available via the GitHub Issues noted here. Technical Support may also be available from Microsoft's Customer Support Services (CSS). If you are a Premier or Unified Support customer, you may reach out to your account manager for further assistance. Otherwise, you may visit Microsoft's [Support for Business site](https://support.serviceshub.microsoft.com/supportforbusiness/create) to open a new support case for this extension.
 
-Note: The .NET MAUI Extension for VS Code is not supported by Microsoft's Customer Support Services at this time. Issues related to the .NET MAUI Extension for VS Code should be reported from VS Code's 'Report Issue' commabnd (available from the Help menu).
+Note: The .NET MAUI extension for VS Code is not supported by Microsoft's Customer Support Services at this time. Issues related to the .NET MAUI extension for VS Code should be reported from VS Code's 'Report Issue' command (available from the Help menu).

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -8,3 +8,5 @@ issues](https://github.com/microsoft/vscode-dotnettools/issues) before filing ne
 ## Microsoft Support Policy  
 
 Support for this extension is primarily made available via the GitHub Issues noted here. Technical Support may also be available from Microsoft's Customer Support Services (CSS). If you are a Premier or Unified Support customer, you may reach out to your account manager for further assistance. Otherwise, you may visit Microsoft's [Support for Business site](https://support.serviceshub.microsoft.com/supportforbusiness/create) to open a new support case for this extension.
+
+Note: The .NET MAUI Extension for VS Code is not supported by Microsoft's Customer Support Services at this time. Issues related to the .NET MAUI Extension for VS Code should be reported from VS Code's 'Report Issue' commabnd (available from the Help menu).


### PR DESCRIPTION
Adding a note that .NET MAUI Extension for VS Code isn't supported by CSS at this time.