### PR TITLE
Add GitHub Action to update issue labels from "prerelease" to "fixed"

### DIFF
--- a/.github/workflows/prerelease-to-fixed.yml
+++ b/.github/workflows/prerelease-to-fixed.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   update-labels:
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/prerelease-to-fixed.yml
+++ b/.github/workflows/prerelease-to-fixed.yml
@@ -4,6 +4,10 @@ name: Update Prerelease Label to Fixed Label
 on:
   workflow_dispatch: # Manual trigger from Actions tab
 
+permissions:
+  issues: write
+  contents: read
+
 jobs:
   update-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/prerelease-to-fixed.yml
+++ b/.github/workflows/prerelease-to-fixed.yml
@@ -4,13 +4,12 @@ name: Update Prerelease Label to Fixed Label
 on:
   workflow_dispatch: # Manual trigger from Actions tab
 
-permissions:
-  issues: write
-  contents: read
-
 jobs:
   update-labels:
     runs-on: ubuntu-latest
+    permissions:
+        issues: write
+        contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/prerelease-to-fixed.yml
+++ b/.github/workflows/prerelease-to-fixed.yml
@@ -11,9 +11,6 @@ permissions:
 jobs:
   update-labels:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/prerelease-to-fixed.yml
+++ b/.github/workflows/prerelease-to-fixed.yml
@@ -1,0 +1,34 @@
+
+name: Update Prerelease Label to Fixed Label
+
+on:
+  workflow_dispatch: # Manual trigger from Actions tab
+
+jobs:
+  update-labels:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up GitHub CLI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gh
+          gh auth setup-git
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Remove "prerelease" and add "fixed"
+        env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+        run: |
+          echo "Finding issues with label 'prerelease'..."
+          issues=$(gh issue list --label "prerelease" --state open --json number --jq '.[].number')
+          if [ -z "$issues" ]; then
+            echo "No issues found with label 'prerelease'."
+            exit 0
+          fi
+          for issue in $issues; do
+            echo "Updating issue #$issue"
+            gh issue edit "$issue" --remove-label "prerelease" --add-label "fixed"


### PR DESCRIPTION
Assuming Copilot wrote this correctly this will allow me to batch update the issues we've tagged with pre-release over the month to remove that label and add the fixed label. Then the fixed issue action will kick off automatically on those. 

Leaving this as something that needs to be triggered manually since release date/time is variable