### PR TITLE
Clarify Windows SDK refresh guidance

### DIFF
--- a/docs/health-check-troubleshooting.md
+++ b/docs/health-check-troubleshooting.md
@@ -65,8 +65,11 @@ The health check derives runtime requirements from the evaluated target framewor
 1. Wait for the active restore, project detection, or installation step to finish.
 2. Select **Open output** and check whether the underlying command is still running or waiting for input.
 3. Select **Recheck** once.
-4. If an SDK or runtime was installed successfully but is still not detected, reload the VS Code window.
-5. If the same state remains, collect logs and report an issue.
+4. If the view appears stale for a reason other than a recent SDK or runtime installation, reload the VS Code window and select **Recheck**.
+5. If an SDK or runtime was installed successfully but is still not detected:
+   - On Windows, exit every VS Code window, then relaunch VS Code from the Start menu or File Explorer so the new process inherits the updated machine environment. **Reload Window** does not replace the environment of the long-lived VS Code application process. If the SDK or runtime is still not detected, restart Windows and select **Recheck**. See [Refresh a stale inherited `PATH`](health-check-installation-windows.md#refresh-a-stale-inherited-path).
+   - On macOS and Linux, use **Reload Window**, then select **Recheck**.
+6. If the same state remains, collect logs and report an issue.
 
 Avoid repeatedly selecting an installation action while an installation is already running.
 


### PR DESCRIPTION
## Why

On Windows, **Reload Window** can retain the long-lived VS Code application environment after a successful SDK or runtime installation, leaving C# Doctor unable to detect the newly installed component. This is the public-doc companion to the vs-green product fix: it gives Windows users the full-process recovery path while preserving ordinary **Reload Window** guidance for macOS/Linux and non-install-related stale UI.

Related issues:
- https://github.com/microsoft/vscode-dotnettools/issues/3513
- https://github.com/microsoft/vscode-dotnettools/issues/3479

## Change

- Distinguish ordinary stale-view recovery from post-install environment refresh.
- Tell Windows users to exit all VS Code windows and relaunch from the Start menu or File Explorer, then restart Windows and recheck if detection still fails.
- Preserve the existing installation-safety and log-reporting guidance.

## Validation

- `git diff --check`
- Confirmed the relative Windows troubleshooting link targets the existing `Refresh a stale inherited PATH` section.
- No targeted Markdown or link-check tooling is present in this repository.

## Base and head

- Base: `main` at `dd2c01a496218d937058e962aa4a71dbdf7440b2`
- Head: `jake-radzikowski-health-check-recovery-docs` at `7799f7eee40473dac12a6de139bcb2b95e342381`
